### PR TITLE
Add additional dependencies to documentation and setup file

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -105,6 +105,8 @@ These packages can easily be installed using using `pip <https://pypi.python.org
 	* `requests <http://docs.python-requests.org/en/master/>`_
 	* `BeautifulSoup4 <https://www.crummy.com/software/BeautifulSoup/>`_
 	* `netCDF4  <http://unidata.github.io/netcdf4-python/>`_
+	* `statsmodels <http://www.statsmodels.org/>`_
+	* `lxml <http://lxml.de/>`_
 
 .. Note::
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,6 @@ setup(
     name = "WDRT",
     version = "1.0.0",
     url = "https://github.com/WEC-Sim/WDRT",
-    install_requires=['numpy', 'scipy', 'requests', 'bs4', 'sklearn','matplotlib','netCDF4'],
+    install_requires=['numpy', 'scipy', 'requests', 'bs4', 'sklearn','matplotlib','netCDF4', 'statsmodels', 'lxml'],
     packages=['WDRT', 'examples'],
 )


### PR DESCRIPTION
When trying to run some of the example cases I found I needed two additional modules:

- statsmodels included in ESSC.py, and
- lxml which was required bs4.

The commit adds these two to the documentation and setup.py file as required dependencies.

Thanks for all the work on WDRT!
 
