### PR TITLE
Return warning if bootstrap is called on Bivariate KDE method.

### DIFF
--- a/WDRT/ESSC.py
+++ b/WDRT/ESSC.py
@@ -414,7 +414,7 @@ class EA:
         '''
         if (self.method == "Bivariate KDE, Log Transform" or
             self.method == "Bivariate KDE"):
-            msg = 'WDRT does not support the bootstrap method for this Bivariate KDE (See Issue #46).'
+            msg = 'WDRT does not support the bootstrap method for this Bivariate KDE (See Issue #47).'
             print(msg)
             return None, None
         #preallocates arrays

--- a/WDRT/ESSC.py
+++ b/WDRT/ESSC.py
@@ -412,6 +412,11 @@ class EA:
             # Calculate boostrap confidence interval
             contourmean_Hs, contourmean_T = pca46022.bootStrap(boot_size=10)
         '''
+        if (self.method == "Bivariate KDE, Log Transform" or
+            self.method == "Bivariate KDE"):
+            msg = 'WDRT does not support the bootstrap method for this Bivariate KDE (See Issue #46).'
+            print(msg)
+            return None, None
         #preallocates arrays
         n = len(self.buoy.Hs)
         Hs_Return_Boot = np.zeros([self.nb_steps,boot_size])


### PR DESCRIPTION
Addresses #47 by throwing a warning if bootstrap is called on the Bivariate KDE method.